### PR TITLE
Fix capitalization of voice parameter in TTS configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ tts:
     # Optional parameters:
     language: "en-US"
     model: "tts-1"
-    voice: "Shimmer"
+    voice: "shimmer"
     speed: "1"


### PR DESCRIPTION
A really small fix to the example that is given, all lower case is expected by the OpenAI API

For example `voice: "Shimmer"` doesn't work.

`voice: "shimmer"` works