### PR TITLE
Endpoint response error logging

### DIFF
--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -10,8 +10,9 @@ class OpenAITTSEngine:
         self._speed = speed
         self._url = url
 
-    def get_tts(self, text: str):
-        """ Makes request to OpenAI TTS engine to convert text into audio"""
+    def get_tts(self, text: str) -> bytes:
+        """ Makes request to OpenAI TTS engine to convert text into audio.
+        Returns audio file content. Raises an exception if the status code is other than 200."""
         headers: dict = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
         data: dict = {
             "model": self._model,

--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -1,5 +1,6 @@
 import requests
 
+
 class OpenAITTSEngine:
 
     def __init__(self, api_key: str, voice: str, model: str, speed: int, url: str):
@@ -19,9 +20,18 @@ class OpenAITTSEngine:
             "response_format": "wav",
             "speed": self._speed
         }
-        return requests.post(self._url, headers=headers, json=data)
+        response = requests.post(self._url, headers=headers, json=data)
+        if response.status_code != 200:
+            raise Exception(
+                f"Failed to convert text to speech [{response.status_code}]: {response.text}")
+        else:
+            return response.content
 
     @staticmethod
     def get_supported_langs() -> list:
         """Returns list of supported languages. Note: the model determines the provides language automatically."""
-        return ["af", "ar", "hy", "az", "be", "bs", "bg", "ca", "zh", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi", "hu", "is", "id", "it", "ja", "kn", "kk", "ko", "lv", "lt", "mk", "ms", "mr", "mi", "ne", "no", "fa", "pl", "pt", "ro", "ru", "sr", "sk", "sl", "es", "sw", "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy"]
+        return ["af", "ar", "hy", "az", "be", "bs", "bg", "ca", "zh", "hr", "cs", "da", "nl",
+                "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi", "hu", "is", "id", "it",
+                "ja", "kn", "kk", "ko", "lv", "lt", "mk", "ms", "mr", "mi", "ne", "no", "fa",
+                "pl", "pt", "ro", "ru", "sr", "sk", "sl", "es", "sw", "sv", "tl", "ta", "th",
+                "tr", "uk", "ur", "vi", "cy"]

--- a/custom_components/openai_tts/tts.py
+++ b/custom_components/openai_tts/tts.py
@@ -80,10 +80,9 @@ class OpenAITTSEntity(TextToSpeechEntity):
             if len(message) > 4096:
                 raise MaxLengthExceeded
 
-            speech = self._engine.get_tts(message)
+            audio_file_content = self._engine.get_tts(message)
 
-            # The response should contain the audio file content
-            return "wav", speech
+            return "wav", audio_file_content
         except MaxLengthExceeded:
             _LOGGER.error("Maximum length of the message exceeded")
         except Exception as e:

--- a/custom_components/openai_tts/tts.py
+++ b/custom_components/openai_tts/tts.py
@@ -83,7 +83,7 @@ class OpenAITTSEntity(TextToSpeechEntity):
             speech = self._engine.get_tts(message)
 
             # The response should contain the audio file content
-            return "wav", speech.content
+            return "wav", speech
         except MaxLengthExceeded:
             _LOGGER.error("Maximum length of the message exceeded")
         except Exception as e:


### PR DESCRIPTION
Added rising of an error and logging for response status codes other than 200 (Success). This is useful for debugging interactions with the OpenAI API.

Slightly reformatted code.

The engine's get_tts now returns bytes instead of the requests Response object.