### PR TITLE
feat: Integrate Kokoro FastAPI & Streaming Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ The OpenAI TTS component for Home Assistant makes it possible to use the OpenAI 
 - **Custom endpoint option** – Allows you to use your own OpenAI compatible API endpoint.
 - **Chime option** – Useful for announcements on speakers. *(See Devices → OpenAI TTS → CONFIGURE button)*
 - **User-configurable chime sounds** – Drop your own chime sound into  `config/custom_components/openai_tts/chime` folder (MP3).
-- **Audio normalization option** – Uses more CPU but improves audio clarity on mobile phones and small speakers. *(See Devices → OpenAI TTS → CONFIGURE button)*
-- ⭐(New!) **Support for new gpt-4o-mini-tts model** – A fast and powerful language model.
-- ⭐(New!) **Text-to-Speech Instructions option** – Instruct the text-to-speech model to speak in a specific way (only works with newest gpt-4o-mini-tts model). [OpenAI new generation audio models](https://openai.com/index/introducing-our-next-generation-audio-models/)
+- **Audio normalization option** – Uses more CPU but improves audio clarity on mobile phones and small speakers.
+- ⭐(New!) **Support for new gpt-4o-mini-tts model** – A fast and powerful language model (note: `gpt-4o-mini-tts` might be a custom model name; official OpenAI models are typically `tts-1`, `tts-1-hd`).
+- ⭐(New!) **Text-to-Speech Instructions option** – Instruct the text-to-speech model to speak in a specific way (model support for this varies). [OpenAI new generation audio models](https://openai.com/index/introducing-our-next-generation-audio-models/)
+- **Dual Engine Support**: Choose between OpenAI's official API (or a compatible proxy) and a local [Kokoro FastAPI](https://github.com/remsky/Kokoro-FastAPI) instance.
+- **Efficient Streaming**: Internally uses streaming from the API for potentially faster and more responsive audio generation, especially for longer texts.
 
 
 
-### *Caution! You need an OpenAI API key and some balance available in your OpenAI account!* ###
-visit: (https://platform.openai.com/docs/pricing)
+### *Caution! You need an OpenAI API key and some balance available in your OpenAI account if using the official OpenAI service!* ###
+For pricing, visit: (https://platform.openai.com/docs/pricing)
+
+Using Kokoro FastAPI as a local engine can avoid OpenAI API costs.
 
 ## YouTube sample video (its not a tutorial!)
 
@@ -42,9 +46,9 @@ data:
     instructions: "Speak like a pirate"  # Instructions for text-to-speach model on how to speak 
 ```
 
-## HACS installation ( *preferred!* ) 
+## HACS installation ( *preferred!* )
 
-1. Go to the sidebar HACS menu 
+1. Go to the sidebar HACS menu
 
 2. Click on the 3-dot overflow menu in the upper right and select the "Custom Repositories" item.
 
@@ -54,7 +58,58 @@ data:
 
 5. You can then click on the "OpenAI TTS Speech Services" repository entry and download it. Restart Home Assistant to apply the component.
 
-6. Add the integration via UI, provide API key and select required model and voice. Multiple instances may be configured.
+## Configuration
+
+After installation (either via HACS or manually), add the OpenAI TTS integration through the Home Assistant UI:
+
+1.  Go to **Settings → Devices & Services**.
+2.  Click **+ Add Integration**.
+3.  Search for "OpenAI TTS" and select it.
+4.  Follow the configuration steps in the dialog.
+
+You can configure the following options during setup:
+
+*   **TTS Engine**: Choose the engine to use.
+    *   `OpenAI (Official or compatible proxy)`: Uses the official OpenAI API or a proxy that implements the same API.
+    *   `Kokoro FastAPI`: Uses a local instance of [Kokoro FastAPI](https://github.com/remsky/Kokoro-FastAPI). This is a great option for local processing and avoiding cloud costs.
+
+*   **OpenAI API Key** (`api_key`):
+    *   Required if you select the "OpenAI" engine and are using the official API.
+    *   Can be left blank if your OpenAI-compatible proxy does not require an API key, or if you select the "Kokoro FastAPI" engine.
+
+*   **OpenAI-compatible API URL** (`url`):
+    *   Only used if "OpenAI" engine is selected.
+    *   Defaults to `https://api.openai.com/v1/audio/speech` for the official OpenAI service.
+    *   Change this if you are using an OpenAI-compatible proxy.
+
+*   **Kokoro FastAPI URL** (`kokoro_url`):
+    *   Only used if "Kokoro FastAPI" engine is selected.
+    *   Enter the full local URL of your Kokoro FastAPI TTS endpoint (e.g., `http://localhost:8002/tts`).
+
+*   **Model** (`model`):
+    *   Select the TTS model (e.g., `tts-1`, `tts-1-hd`).
+    *   Availability might depend on the chosen engine and your specific endpoint. The list provides common OpenAI models, but you can enter a custom model name if your backend supports it.
+
+*   **Voice** (`voice`):
+    *   Select the desired voice (e.g., `alloy`, `echo`, `shimmer`).
+    *   Availability might depend on the chosen engine and your specific endpoint. The list provides common OpenAI voices, but you can enter a custom voice name.
+
+*   **Speed** (`speed`):
+    *   Adjust the speech speed (range: 0.25 to 4.0, where 1.0 is the default).
+
+Multiple instances of the integration can be configured, for example, to use different engines, models, or voices simultaneously.
+
+### Modifying Options After Setup
+
+Some options can be modified after the initial setup by navigating to the integration's card under **Settings → Devices & Services**, clicking the three dots, and selecting "Configure" (or by clicking the "CONFIGURE" button on the device page from the "OpenAI TTS" entry). These include:
+- Model
+- Voice
+- Speed
+- Instructions for the TTS model
+- Chime sound enablement and selection
+- Audio normalization
+
+Note: To change the TTS Engine, API Key, or main URLs (OpenAI URL, Kokoro URL), you will need to remove and re-add the integration.
 
 ## Manual installation
 

--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -29,22 +29,57 @@ from .const import (
     MODELS,
     VOICES,
     UNIQUE_ID,
-    CONF_CHIME_ENABLE,    # Use constant for chime enable toggle
+    CONF_CHIME_ENABLE,
     CONF_CHIME_SOUND,
     CONF_NORMALIZE_AUDIO,
     CONF_INSTRUCTIONS,
+    # New constants
+    CONF_TTS_ENGINE,
+    OPENAI_ENGINE,
+    KOKORO_FASTAPI_ENGINE,
+    TTS_ENGINES,
+    DEFAULT_TTS_ENGINE,
+    CONF_KOKORO_URL,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
+# Removed class-level data_schema, it will be dynamic
+
 def generate_entry_id() -> str:
     return str(uuid.uuid4())
 
-async def validate_user_input(user_input: dict):
-    if user_input.get(CONF_MODEL) is None:
-        raise ValueError("Model is required")
-    if user_input.get(CONF_VOICE) is None:
-        raise ValueError("Voice is required")
+async def validate_config_input(user_input: dict):
+    """Validate common and engine-specific fields."""
+    errors = {}
+    # Common validations
+    if not user_input.get(CONF_MODEL):
+        errors[CONF_MODEL] = "model_required" # Assuming this key exists in strings.json or add it
+    if not user_input.get(CONF_VOICE):
+        errors[CONF_VOICE] = "voice_required" # Assuming this key exists in strings.json or add it
+
+    # Engine specific validations
+    engine_type = user_input.get(CONF_TTS_ENGINE)
+    if engine_type == OPENAI_ENGINE:
+        if not user_input.get(CONF_URL): # OpenAI URL has a default but user might clear it
+            errors[CONF_URL] = "url_required_openai" # Add to strings.json
+        # API key for OpenAI is generally good practice, but some proxies might not need it.
+        # No hard error here, but could be a warning or different handling.
+    elif engine_type == KOKORO_FASTAPI_ENGINE:
+        if not user_input.get(CONF_KOKORO_URL):
+            errors[CONF_KOKORO_URL] = "kokoro_url_required" # Add to strings.json
+
+    if errors:
+        # To make Voluptuous happy and show field-specific errors,
+        # we should ideally integrate this into the schema validation step by step,
+        # or use a different error reporting mechanism if just returning a dict of errors.
+        # For now, raising a generic error if any specific field error is found.
+        # A better way is to return errors and let async_show_form handle them.
+        # This simple implementation will put error on "base".
+        # Let's refine this to return the errors dict.
+        pass # Errors will be returned and handled by async_show_form
+
+    return errors # Return dict of errors
 
 def get_chime_options() -> list[dict[str, str]]:
     """
@@ -69,64 +104,107 @@ def get_chime_options() -> list[dict[str, str]]:
 class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenAI TTS."""
     VERSION = 1
-    data_schema = vol.Schema({
-        vol.Optional(CONF_API_KEY): str,
-        vol.Optional(CONF_URL, default="https://api.openai.com/v1/audio/speech"): str,
-        vol.Optional(CONF_SPEED, default=1.0): selector({
-            "number": {
-                "min": 0.25,
-                "max": 4.0,
-                "step": 0.05,
-                "mode": "slider"
-            }
-        }),
-        vol.Required(CONF_MODEL, default="tts-1"): selector({
-            "select": {
-                "options": MODELS,
-                "mode": "dropdown",
-                "sort": True,
-                "custom_value": True
-            }
-        }),
-        vol.Required(CONF_VOICE, default="shimmer"): selector({
-            "select": {
-                "options": VOICES,
-                "mode": "dropdown",
-                "sort": True,
-                "custom_value": True
-            }
-        })
-    })
+    # Connection class and data not needed for this version of config flow
+    # CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    # data: dict[str, Any] = {} # To store data across steps if needed
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
-        errors = {}
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            try:
-                await validate_user_input(user_input)
-                entry_id = generate_entry_id()
-                user_input[UNIQUE_ID] = entry_id
-                await self.async_set_unique_id(entry_id)
-                hostname = urlparse(user_input[CONF_URL]).hostname
-                return self.async_create_entry(
-                    title=f"OpenAI TTS ({hostname}, {user_input[CONF_MODEL]})",
-                    data=user_input
-                )
-            except data_entry_flow.AbortFlow:
-                return self.async_abort(reason="already_configured")
-            except HomeAssistantError as e:
-                _LOGGER.exception(str(e))
-                errors["base"] = str(e)
-            except ValueError as e:
-                _LOGGER.exception(str(e))
-                errors["base"] = str(e)
-            except Exception as e:
-                _LOGGER.exception(str(e))
-                errors["base"] = "unknown_error"
+            # Store current input to repopulate form if errors occur
+            # self.data.update(user_input) # If using self.data for multi-step
+
+            # Validate common and engine-specific fields
+            validation_errors = await validate_config_input(user_input)
+            errors.update(validation_errors)
+
+            if not errors:
+                try:
+                    entry_id = generate_entry_id()
+                    # await self.async_set_unique_id(entry_id) # Deprecated, unique_id handled by data
+                    user_input[UNIQUE_ID] = entry_id
+
+                    title = "OpenAI TTS"
+                    if user_input.get(CONF_TTS_ENGINE) == KOKORO_FASTAPI_ENGINE:
+                        kokoro_url_parsed = urlparse(user_input.get(CONF_KOKORO_URL, ""))
+                        title = f"Kokoro FastAPI TTS ({kokoro_url_parsed.hostname}, {user_input.get(CONF_MODEL)})"
+                    else: # OpenAI or compatible
+                        url_parsed = urlparse(user_input.get(CONF_URL, ""))
+                        title = f"OpenAI TTS ({url_parsed.hostname}, {user_input.get(CONF_MODEL)})"
+
+                    # Clean up data based on engine type
+                    if user_input.get(CONF_TTS_ENGINE) == KOKORO_FASTAPI_ENGINE:
+                        user_input.pop(CONF_API_KEY, None)
+                        user_input.pop(CONF_URL, None)
+                    else: # OpenAI
+                        user_input.pop(CONF_KOKORO_URL, None)
+
+
+                    return self.async_create_entry(title=title, data=user_input)
+                except data_entry_flow.AbortFlow: # Should not happen if unique_id is always new
+                    return self.async_abort(reason="already_configured")
+                except Exception as e:
+                    _LOGGER.exception("Unexpected error creating entry: %s", e)
+                    errors["base"] = "unknown" # Use "unknown" from strings.json
+
+        # Determine current engine for schema or default
+        current_engine = user_input.get(CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE) if user_input else DEFAULT_TTS_ENGINE
+
+        # Build schema dynamically
+        data_schema_user = {
+            vol.Required(CONF_TTS_ENGINE, default=current_engine): selector({
+                "select": {
+                    "options": TTS_ENGINES,
+                    "translation_key": "tts_engine" # Uses selector.<domain>.<translation_key>
+                }
+            }),
+        }
+
+        if current_engine == OPENAI_ENGINE:
+            data_schema_user.update({
+                vol.Optional(CONF_API_KEY): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+                vol.Required(CONF_URL, default="https://api.openai.com/v1/audio/speech"): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
+            })
+        elif current_engine == KOKORO_FASTAPI_ENGINE:
+            data_schema_user.update({
+                vol.Required(CONF_KOKORO_URL): TextSelector(TextSelectorConfig(type=TextSelectorType.URL)),
+            })
+
+        data_schema_user.update({
+            vol.Required(CONF_MODEL, default=user_input.get(CONF_MODEL, "tts-1") if user_input else "tts-1"): selector({
+                "select": {
+                    "options": MODELS, # Consider making this dynamic per engine in future
+                    "mode": "dropdown",
+                    "sort": True,
+                    "custom_value": True,
+                    "translation_key": "model"
+                }
+            }),
+            vol.Required(CONF_VOICE, default=user_input.get(CONF_VOICE, "shimmer") if user_input else "shimmer"): selector({
+                "select": {
+                    "options": VOICES, # Consider making this dynamic per engine in future
+                    "mode": "dropdown",
+                    "sort": True,
+                    "custom_value": True,
+                    "translation_key": "voice"
+                }
+            }),
+            vol.Optional(CONF_SPEED, default=user_input.get(CONF_SPEED, 1.0) if user_input else 1.0): selector({
+                "number": {
+                    "min": 0.25,
+                    "max": 4.0,
+                    "step": 0.05,
+                    "mode": "slider"
+                }
+            }),
+        })
+
         return self.async_show_form(
             step_id="user",
-            data_schema=self.data_schema,
+            data_schema=vol.Schema(data_schema_user),
             errors=errors,
-            description_placeholders=user_input
+            # description_placeholders can be used if needed, e.g. for API key hints
         )
 
     @staticmethod
@@ -136,62 +214,58 @@ class OpenAITTSConfigFlow(ConfigFlow, domain=DOMAIN):
 class OpenAITTSOptionsFlow(OptionsFlow):
     """Handle options flow for OpenAI TTS."""
     async def async_step_init(self, user_input: dict | None = None):
+        """Handle options flow."""
+        errors: dict[str, str] = {}
+        # Determine the engine type from the main config entry
+        engine_type = self.config_entry.data.get(CONF_TTS_ENGINE, DEFAULT_TTS_ENGINE)
+
         if user_input is not None:
+            # Here you could add validation for options if needed
+            # For example, ensure instructions are not too long, etc.
+            # For now, just creating the entry with new options.
             return self.async_create_entry(title="", data=user_input)
-        # Retrieve chime options using the executor to avoid blocking the event loop.
+
         chime_options = await self.hass.async_add_executor_job(get_chime_options)
-        options_schema = vol.Schema({
-            # Use constant for chime enable toggle so the label comes from strings.json
-            vol.Optional(
-                CONF_CHIME_ENABLE,
-                default=self.config_entry.options.get(CONF_CHIME_ENABLE, self.config_entry.data.get(CONF_CHIME_ENABLE, False))
-            ): selector({"boolean": {}}),
 
-            vol.Optional(
-                CONF_CHIME_SOUND,
-                default=self.config_entry.options.get(CONF_CHIME_SOUND, self.config_entry.data.get(CONF_CHIME_SOUND, "threetone.mp3"))
-            ): selector({
-                "select": {
-                    "options": chime_options
-                }
+        # Get current values for defaults, from options or from data
+        current_model = self.config_entry.options.get(CONF_MODEL, self.config_entry.data.get(CONF_MODEL, "tts-1"))
+        current_voice = self.config_entry.options.get(CONF_VOICE, self.config_entry.data.get(CONF_VOICE, "shimmer"))
+        current_speed = self.config_entry.options.get(CONF_SPEED, self.config_entry.data.get(CONF_SPEED, 1.0))
+        current_instructions = self.config_entry.options.get(CONF_INSTRUCTIONS, self.config_entry.data.get(CONF_INSTRUCTIONS, "")) # Ensure string default
+        current_chime_enable = self.config_entry.options.get(CONF_CHIME_ENABLE, self.config_entry.data.get(CONF_CHIME_ENABLE, False))
+        current_chime_sound = self.config_entry.options.get(CONF_CHIME_SOUND, self.config_entry.data.get(CONF_CHIME_SOUND, "threetone.mp3"))
+        current_normalize_audio = self.config_entry.options.get(CONF_NORMALIZE_AUDIO, self.config_entry.data.get(CONF_NORMALIZE_AUDIO, False))
+
+        # TODO: Potentially make MODELS and VOICES dynamic based on engine_type
+        # For now, using global MODELS and VOICES
+        # Example:
+        # available_models = KOKORO_MODELS if engine_type == KOKORO_FASTAPI_ENGINE else MODELS
+        # available_voices = KOKORO_VOICES if engine_type == KOKORO_FASTAPI_ENGINE else VOICES
+        available_models = MODELS
+        available_voices = VOICES
+
+        options_schema_dict = {
+            vol.Optional(CONF_MODEL, default=current_model): selector({
+                "select": {"options": available_models, "mode": "dropdown", "sort": True, "custom_value": True, "translation_key": "model"}
             }),
-
-            vol.Optional(
-                CONF_SPEED,
-                default=self.config_entry.options.get(CONF_SPEED, self.config_entry.data.get(CONF_SPEED, 1.0))
-            ): selector({
-                "number": {
-                    "min": 0.25,
-                    "max": 4.0,
-                    "step": 0.05,
-                    "mode": "slider"
-                }
+            vol.Optional(CONF_VOICE, default=current_voice): selector({
+                "select": {"options": available_voices, "mode": "dropdown", "sort": True, "custom_value": True, "translation_key": "voice"}
             }),
-
-            vol.Optional(
-                CONF_VOICE,
-                default=self.config_entry.options.get(CONF_VOICE, self.config_entry.data.get(CONF_VOICE, "shimmer"))
-            ): selector({
-                "select": {
-                    "options": VOICES,
-                    "mode": "dropdown",
-                    "sort": True,
-                    "custom_value": True
-                }
+            vol.Optional(CONF_SPEED, default=current_speed): selector({
+                "number": {"min": 0.25, "max": 4.0, "step": 0.05, "mode": "slider"}
             }),
-
-
-            vol.Optional(
-                 CONF_INSTRUCTIONS,
-                 default=self.config_entry.options.get(CONF_INSTRUCTIONS, self.config_entry.data.get(CONF_INSTRUCTIONS, None))
-            ): TextSelector(
-                TextSelectorConfig(type=TextSelectorType.TEXT,multiline=True)
+            vol.Optional(CONF_INSTRUCTIONS, default=current_instructions): TextSelector(
+                TextSelectorConfig(type=TextSelectorType.TEXT, multiline=True)
             ),
+            vol.Optional(CONF_CHIME_ENABLE, default=current_chime_enable): selector({"boolean": {}}),
+            vol.Optional(CONF_CHIME_SOUND, default=current_chime_sound): selector({
+                "select": {"options": chime_options}
+            }),
+            vol.Optional(CONF_NORMALIZE_AUDIO, default=current_normalize_audio): selector({"boolean": {}})
+        }
 
-            # Normalization toggle using its constant; label will be picked from strings.json.
-            vol.Optional(
-                CONF_NORMALIZE_AUDIO,
-                default=self.config_entry.options.get(CONF_NORMALIZE_AUDIO, self.config_entry.data.get(CONF_NORMALIZE_AUDIO, False))
-            ): selector({"boolean": {}})
-        })
-        return self.async_show_form(step_id="init", data_schema=options_schema)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(options_schema_dict),
+            errors=errors
+        )

--- a/custom_components/openai_tts/const.py
+++ b/custom_components/openai_tts/const.py
@@ -10,7 +10,17 @@ CONF_SPEED = "speed"
 CONF_URL = "url"
 UNIQUE_ID = "unique_id"
 
-MODELS = ["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
+# Engine selection
+CONF_TTS_ENGINE = "tts_engine"
+OPENAI_ENGINE = "openai"
+KOKORO_FASTAPI_ENGINE = "kokoro_fastapi"
+TTS_ENGINES = [OPENAI_ENGINE, KOKORO_FASTAPI_ENGINE]
+DEFAULT_TTS_ENGINE = OPENAI_ENGINE
+
+# Kokoro specific
+CONF_KOKORO_URL = "kokoro_url"
+
+MODELS = ["tts-1", "tts-1-hd", "gpt-4o-mini-tts"] # Note: gpt-4o-mini-tts may be custom
 VOICES = ["alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"]
 
 CONF_CHIME_ENABLE = "chime"

--- a/custom_components/openai_tts/strings.json
+++ b/custom_components/openai_tts/strings.json
@@ -2,33 +2,81 @@
   "config": {
     "step": {
       "user": {
-        "title": "Add text-to-speech engine",
-        "description": "See documentation for further info.",
+        "title": "Add Text-to-Speech Engine",
+        "description": "Choose your TTS engine and provide the necessary configuration. See documentation for further info.",
         "data": {
-          "api_key": "Enter OpenAI API key",
-          "speed": "Speed (0.25 to 4.0, where 1.0 is default)",
+          "tts_engine": "TTS Engine",
+          "api_key": "OpenAI API Key",
+          "url": "OpenAI-compatible API URL",
+          "kokoro_url": "Kokoro FastAPI URL",
           "model": "Model",
           "voice": "Voice",
-          "url": "Enter an OpenAI-compatible endpoint (optionally include a port number)."
+          "speed": "Speed (0.25 to 4.0, where 1.0 is default)"
+        },
+        "data_description": {
+          "api_key": "Required for official OpenAI engine. Leave blank if using Kokoro FastAPI or if not required by your OpenAI-compatible endpoint.",
+          "url": "The API endpoint for OpenAI or your OpenAI-compatible proxy. Leave blank if using Kokoro FastAPI. Defaults to official OpenAI endpoint if not specified for OpenAI engine.",
+          "kokoro_url": "The full URL for your Kokoro FastAPI TTS endpoint (e.g., http://localhost:8002/tts). Required if Kokoro FastAPI engine is selected."
         }
       }
     },
     "error": {
-      "wrong_api_key": "Invalid API key. Please enter a valid API key."
+      "wrong_api_key": "Invalid API key. Please enter a valid API key.",
+      "cannot_connect": "Failed to connect to the specified URL.",
+      "unknown": "An unexpected error occurred.",
+      "model_required": "Model selection is required.",
+      "voice_required": "Voice selection is required.",
+      "url_required_openai": "API URL is required for the OpenAI engine.",
+      "kokoro_url_required": "Kokoro FastAPI URL is required for the Kokoro FastAPI engine.",
+      "invalid_url": "Invalid URL format."
+    },
+    "abort": {
+      "already_configured": "This TTS engine configuration is already registered."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Configure TTS options",
+        "title": "Configure TTS Options",
+        "description": "Adjust common TTS settings. To change engine type or main URLs, please re-add the integration.",
         "data": {
-          "chime": "Enable chime sound prior speech (useful for announcements)",
-          "chime_sound": "Chime sound",
-          "speed": "Speed (0.25 to 4.0)",
+          "model": "Model (Note: Engine type cannot be changed here)",
           "voice": "Voice",
-          "instructions": "Instructions",
-          "normalize_audio": "Enable loudness for generated audio (uses more CPU)"
+          "speed": "Speed (0.25 to 4.0)",
+          "instructions": "Instructions (if supported by model)",
+          "chime": "Enable chime sound prior to speech (useful for announcements)",
+          "chime_sound": "Chime sound",
+          "normalize_audio": "Enable loudness normalization for generated audio (uses more CPU)"
         }
+      }
+    }
+  },
+  "selector": {
+    "tts_engine": {
+      "options": {
+        "openai": "OpenAI (Official or compatible proxy)",
+        "kokoro_fastapi": "Kokoro FastAPI"
+      }
+    },
+    "model": {
+      "options": {
+        "tts-1": "OpenAI TTS-1",
+        "tts-1-hd": "OpenAI TTS-1-HD (High Definition)",
+        "gpt-4o-mini-tts": "GPT-4o-mini-TTS (Custom/Experimental)"
+      }
+    },
+    "voice": {
+      "options": {
+        "alloy": "Alloy",
+        "ash": "Ash",
+        "ballad": "Ballad (Experimental/Custom)",
+        "coral": "Coral (Experimental/Custom)",
+        "echo": "Echo",
+        "fable": "Fable",
+        "onyx": "Onyx",
+        "nova": "Nova",
+        "sage": "Sage (Experimental/Custom)",
+        "shimmer": "Shimmer"
       }
     }
   }

--- a/custom_components/openai_tts/tests/__init__.py
+++ b/custom_components/openai_tts/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/custom_components/openai_tts/tests/test_openaitts_engine.py
+++ b/custom_components/openai_tts/tests/test_openaitts_engine.py
@@ -1,0 +1,205 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+from homeassistant.exceptions import HomeAssistantError
+
+# Adjust the import path according to your project structure
+from custom_components.openai_tts.openaitts_engine import OpenAITTSEngine
+from custom_components.openai_tts.const import (
+    KOKORO_FASTAPI_ENGINE, # Assuming this is defined
+    OPENAI_ENGINE
+)
+
+class TestOpenAITTSEngine(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.api_key = "test_api_key"
+        self.openai_voice = "alloy"
+        self.openai_model = "tts-1"
+        self.openai_speed = 1.0
+        self.openai_url = "https://api.openai.com/v1/audio/speech"
+
+        self.kokoro_voice = "kokoro_voice"
+        self.kokoro_model = "kokoro_model"
+        self.kokoro_speed = 1.2
+        self.kokoro_url = "http://localhost:8002/tts"
+
+    async def test_init_openai_engine(self):
+        """Test engine initialization with OpenAI configuration."""
+        engine = OpenAITTSEngine(
+            api_key=self.api_key,
+            voice=self.openai_voice,
+            model=self.openai_model,
+            speed=self.openai_speed,
+            url=self.openai_url
+        )
+        self.assertIsNotNone(engine._session)
+        self.assertEqual(engine._api_key, self.api_key)
+        self.assertEqual(engine._url, self.openai_url)
+        await engine.close()
+
+    async def test_init_kokoro_engine(self):
+        """Test engine initialization with Kokoro FastAPI configuration."""
+        engine = OpenAITTSEngine(
+            api_key=None, # Kokoro might not use an API key
+            voice=self.kokoro_voice,
+            model=self.kokoro_model,
+            speed=self.kokoro_speed,
+            url=self.kokoro_url
+        )
+        self.assertIsNotNone(engine._session)
+        self.assertIsNone(engine._api_key)
+        self.assertEqual(engine._url, self.kokoro_url)
+        await engine.close()
+
+    @patch("aiohttp.ClientSession")
+    async def test_kokoro_configuration_request(self, MockClientSession):
+        """Test that Kokoro engine makes requests to the correct URL without API key if not provided."""
+        mock_session_instance = MockClientSession.return_value
+        mock_post_response = AsyncMock()
+        mock_post_response.status = 200
+        mock_post_response.content.iter_any = AsyncMock(return_value=[b"chunk1", b"chunk2"])
+        mock_session_instance.post = AsyncMock(return_value=mock_post_response)
+
+        engine = OpenAITTSEngine(
+            api_key=None,  # No API key for Kokoro
+            voice=self.kokoro_voice,
+            model=self.kokoro_model,
+            speed=self.kokoro_speed,
+            url=self.kokoro_url
+        )
+
+        text_to_speak = "Hello Kokoro"
+        async for _ in engine.get_tts(text_to_speak):
+            pass
+
+        mock_session_instance.post.assert_called_once()
+        args, kwargs = mock_session_instance.post.call_args
+        self.assertEqual(args[0], self.kokoro_url)
+        self.assertNotIn("Authorization", kwargs["headers"])
+        self.assertEqual(kwargs["json"]["input"], text_to_speak)
+        self.assertEqual(kwargs["json"]["voice"], self.kokoro_voice)
+        await engine.close()
+
+    @patch("aiohttp.ClientSession")
+    async def test_openai_configuration_request_with_key(self, MockClientSession):
+        """Test that OpenAI engine makes requests to the correct URL with API key."""
+        mock_session_instance = MockClientSession.return_value
+        mock_post_response = AsyncMock()
+        mock_post_response.status = 200
+        mock_post_response.content.iter_any = AsyncMock(return_value=[b"chunk1", b"chunk2"])
+        mock_session_instance.post = AsyncMock(return_value=mock_post_response)
+
+        engine = OpenAITTSEngine(
+            api_key=self.api_key,
+            voice=self.openai_voice,
+            model=self.openai_model,
+            speed=self.openai_speed,
+            url=self.openai_url
+        )
+
+        text_to_speak = "Hello OpenAI"
+        async for _ in engine.get_tts(text_to_speak):
+            pass
+
+        mock_session_instance.post.assert_called_once()
+        args, kwargs = mock_session_instance.post.call_args
+        self.assertEqual(args[0], self.openai_url)
+        self.assertIn("Authorization", kwargs["headers"])
+        self.assertEqual(kwargs["headers"]["Authorization"], f"Bearer {self.api_key}")
+        self.assertEqual(kwargs["json"]["input"], text_to_speak)
+        await engine.close()
+
+
+    @patch("aiohttp.ClientSession")
+    async def test_streaming_success(self, MockClientSession):
+        """Test successful streaming of audio chunks."""
+        mock_session_instance = MockClientSession.return_value
+        mock_post_response = AsyncMock()
+        mock_post_response.status = 200
+        # Simulate iter_any() behavior
+        async def dummy_iter_any():
+            yield b"stream_chunk_1"
+            yield b"stream_chunk_2"
+        mock_post_response.content.iter_any = dummy_iter_any
+        mock_session_instance.post = AsyncMock(return_value=mock_post_response)
+
+        engine = OpenAITTSEngine(self.api_key, self.openai_voice, self.openai_model, self.openai_speed, self.openai_url)
+
+        collected_chunks = []
+        async for chunk in engine.get_tts("test streaming"):
+            collected_chunks.append(chunk)
+
+        self.assertEqual(collected_chunks, [b"stream_chunk_1", b"stream_chunk_2"])
+        await engine.close()
+
+    @patch("aiohttp.ClientSession")
+    async def test_api_error_handling_streaming(self, MockClientSession):
+        """Test API error (ClientResponseError) handling during streaming."""
+        mock_session_instance = MockClientSession.return_value
+        mock_session_instance.post = AsyncMock(
+            side_effect=aiohttp.ClientResponseError(
+                request_info=MagicMock(),
+                history=MagicMock(),
+                status=400,
+                message="Test API Error"
+            )
+        )
+
+        engine = OpenAITTSEngine(self.api_key, self.openai_voice, self.openai_model, self.openai_speed, self.openai_url)
+
+        with self.assertRaises(HomeAssistantError) as context:
+            async for _ in engine.get_tts("test api error"):
+                pass
+        self.assertIn("Network error occurred while fetching TTS audio: Test API Error", str(context.exception))
+        await engine.close()
+
+    @patch("aiohttp.ClientSession")
+    async def test_network_error_handling_streaming(self, MockClientSession):
+        """Test general network error (ClientError) handling during streaming."""
+        mock_session_instance = MockClientSession.return_value
+        mock_session_instance.post = AsyncMock(side_effect=aiohttp.ClientError("Test Network Connection Error"))
+
+        engine = OpenAITTSEngine(self.api_key, self.openai_voice, self.openai_model, self.openai_speed, self.openai_url)
+
+        with self.assertRaises(HomeAssistantError) as context:
+            async for _ in engine.get_tts("test network error"):
+                pass
+        self.assertIn("Network error occurred while fetching TTS audio: Test Network Connection Error", str(context.exception))
+        await engine.close()
+
+    @patch("aiohttp.ClientSession")
+    async def test_cancelled_error_handling(self, MockClientSession):
+        """Test CancelledError propagation."""
+        mock_session_instance = MockClientSession.return_value
+        mock_session_instance.post = AsyncMock(side_effect=asyncio.CancelledError)
+
+        engine = OpenAITTSEngine(self.api_key, self.openai_voice, self.openai_model, self.openai_speed, self.openai_url)
+
+        with self.assertRaises(asyncio.CancelledError):
+            async for _ in engine.get_tts("test cancellation"):
+                pass
+        # Note: We don't call await engine.close() here as the operation was cancelled.
+        # Depending on how session is managed, it might be closed by a higher level or GC.
+        # For this test, we confirm CancelledError propagates.
+        # If there's a specific cleanup expected even on cancellation, that needs testing.
+        # Manually close if necessary for subsequent tests if session is reused by test runner
+        if engine._session and not engine._session.closed:
+             await engine._session.close()
+
+
+    @patch("aiohttp.ClientSession")
+    async def test_close_method(self, MockClientSession):
+        """Test that the close method correctly closes the aiohttp session."""
+        mock_session_instance = MockClientSession.return_value
+        mock_session_instance.close = AsyncMock() # Make close an AsyncMock
+
+        engine = OpenAITTSEngine(self.api_key, self.openai_voice, self.openai_model, self.openai_speed, self.openai_url)
+        await engine.close()
+
+        mock_session_instance.close.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/custom_components/openai_tts/tests/test_tts.py
+++ b/custom_components/openai_tts/tests/test_tts.py
@@ -1,0 +1,254 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+
+# Adjust import paths as necessary
+from custom_components.openai_tts.tts import OpenAITTSEntity, async_setup_entry
+from custom_components.openai_tts.openaitts_engine import OpenAITTSEngine
+from custom_components.openai_tts.const import (
+    DOMAIN,
+    CONF_API_KEY,
+    CONF_MODEL,
+    CONF_VOICE,
+    CONF_SPEED,
+    CONF_URL,
+    CONF_TTS_ENGINE,
+    OPENAI_ENGINE,
+    KOKORO_FASTAPI_ENGINE,
+    CONF_KOKORO_URL,
+    UNIQUE_ID, # Assuming UNIQUE_ID is used in config
+)
+
+# Minimal HomeAssistant mock
+class MockHomeAssistant(MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = {}
+        # Mock async_add_executor_job to run functions directly for simplicity in these tests
+        # For more complex scenarios, you might need a proper event loop and executor.
+        self.async_add_executor_job = AsyncMock(side_effect=lambda func, *args: func(*args))
+
+
+class TestOpenAITTSEntity(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.hass = MockHomeAssistant()
+
+        self.openai_config_data = {
+            CONF_TTS_ENGINE: OPENAI_ENGINE,
+            CONF_API_KEY: "fake_openai_key",
+            CONF_URL: "https://api.openai.com/v1/audio/speech",
+            CONF_MODEL: "tts-1",
+            CONF_VOICE: "alloy",
+            CONF_SPEED: 1.0,
+            UNIQUE_ID: "openai-test-unique-id"
+        }
+        self.kokoro_config_data = {
+            CONF_TTS_ENGINE: KOKORO_FASTAPI_ENGINE,
+            CONF_KOKORO_URL: "http://localhost:8002/tts",
+            CONF_MODEL: "kokoro-model",
+            CONF_VOICE: "kokoro-voice",
+            CONF_SPEED: 1.0,
+            UNIQUE_ID: "kokoro-test-unique-id"
+            # No API key for Kokoro in this test setup
+        }
+        self.mock_engine = AsyncMock(spec=OpenAITTSEngine)
+        # Default title for config entry, can be overridden in tests
+        self.config_entry_title = "Test TTS Config"
+
+
+    def _setup_entity(self, config_data: dict) -> OpenAITTSEntity:
+        """Helper to create an entity instance with mocked ConfigEntry and engine."""
+        mock_config_entry = MagicMock(spec=ConfigEntry)
+        mock_config_entry.data = config_data
+        mock_config_entry.options = {} # Start with empty options
+        # Mock the title property of the config_entry
+        type(mock_config_entry).title = PropertyMock(return_value=self.config_entry_title)
+
+        # The engine is now created inside async_setup_entry, so we patch OpenAITTSEngine directly
+        # or we can pass a pre-mocked engine if we refactor entity creation slightly for tests
+        # For now, let's assume we pass the engine in if testing entity methods directly.
+        # If testing async_setup_entry, we'd patch the engine's constructor.
+
+        entity = OpenAITTSEntity(self.hass, mock_config_entry, self.mock_engine)
+        return entity
+
+    async def test_device_info_openai(self):
+        """Test device_info for OpenAI configuration."""
+        self.config_entry_title = "OpenAI TTS tts-1" # Match expected name format
+        entity = self._setup_entity(self.openai_config_data)
+        device_info = entity.device_info
+        self.assertEqual(device_info["manufacturer"], "OpenAI")
+        self.assertEqual(device_info["model"], self.openai_config_data[CONF_MODEL])
+        self.assertEqual(device_info["name"], self.config_entry_title)
+
+
+    async def test_device_info_kokoro(self):
+        """Test device_info for Kokoro FastAPI configuration."""
+        self.config_entry_title = "Kokoro FastAPI TTS kokoro-model" # Match expected name format
+        entity = self._setup_entity(self.kokoro_config_data)
+        device_info = entity.device_info
+        self.assertEqual(device_info["manufacturer"], "Kokoro FastAPI")
+        self.assertEqual(device_info["model"], self.kokoro_config_data[CONF_MODEL])
+        self.assertEqual(device_info["name"], self.config_entry_title)
+
+    async def test_name_property_openai(self):
+        """Test name property for OpenAI configuration."""
+        self.config_entry_title = "OpenAI TTS tts-1"
+        entity = self._setup_entity(self.openai_config_data)
+        self.assertEqual(entity.name, self.config_entry_title)
+
+    async def test_name_property_kokoro(self):
+        """Test name property for Kokoro FastAPI configuration."""
+        self.config_entry_title = "Kokoro FastAPI TTS kokoro-model"
+        entity = self._setup_entity(self.kokoro_config_data)
+        self.assertEqual(entity.name, self.config_entry_title)
+
+    async def test_async_get_tts_audio_streaming_success(self):
+        """Test successful audio streaming via async_get_tts_audio."""
+        entity = self._setup_entity(self.kokoro_config_data) # Using Kokoro for this test
+
+        test_audio_chunks = [b"Hello", b" ", b"World"]
+        # Mock the engine's get_tts to be an async generator
+        async def mock_stream_audio(*args, **kwargs):
+            for chunk in test_audio_chunks:
+                yield chunk
+        self.mock_engine.get_tts = mock_stream_audio
+
+        # Call the method that internally calls get_tts_audio
+        fmt, audio_data = await entity.async_get_tts_audio("Hello World", "en-US", options={})
+
+        self.assertEqual(fmt, "mp3") # Assuming mp3 is the format
+        self.assertEqual(audio_data, b"Hello World")
+        # self.mock_engine.get_tts.assert_called_once_with("Hello World", speed=ANY, voice=ANY, instructions=ANY)
+        # We can make assertions about arguments passed to self.mock_engine.get_tts if needed
+
+    @patch("subprocess.run") # Patch subprocess.run
+    async def test_async_get_tts_audio_with_ffmpeg_processing(self, mock_subprocess_run):
+        """Test audio streaming with ffmpeg (chime/normalization) correctly called."""
+        # Setup mock for subprocess.run
+        mock_subprocess_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        # Enable chime to trigger ffmpeg processing
+        entity = self._setup_entity(self.kokoro_config_data)
+        entity._config.options = { # Simulate options being set
+            "chime": True,
+            "chime_sound": "threetone.mp3",
+            "normalize_audio": True
+        }
+
+        test_audio_chunks = [b"raw_audio_chunk1", b"raw_audio_chunk2"]
+        expected_raw_audio = b"raw_audio_chunk1raw_audio_chunk2"
+
+        async def mock_stream_audio(*args, **kwargs):
+            for chunk in test_audio_chunks:
+                yield chunk
+        self.mock_engine.get_tts = mock_stream_audio
+
+        # Mock tempfile operations
+        mock_temp_file_tts = MagicMock()
+        mock_temp_file_tts.name = "/tmp/fake_tts.mp3"
+        mock_temp_file_tts.__enter__.return_value = mock_temp_file_tts # For 'with' statement
+
+        mock_temp_file_merged = MagicMock()
+        mock_temp_file_merged.name = "/tmp/fake_merged.mp3"
+        mock_temp_file_merged.__enter__.return_value = mock_temp_file_merged
+
+        # Patch tempfile.NamedTemporaryFile and open
+        with patch("tempfile.NamedTemporaryFile", side_effect=[mock_temp_file_tts, mock_temp_file_merged]) as mock_tempfile_creator, \
+             patch("builtins.open", MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"processed_audio")))) as mock_open, \
+             patch("os.path.join", MagicMock(return_value="/mock/path/to/chime.mp3")), \
+             patch("os.path.dirname", MagicMock(return_value="/mock/path")), \
+             patch("os.remove") as mock_os_remove:
+
+            fmt, audio_data = await entity.async_get_tts_audio("Test message", "en-US", options={})
+
+            self.assertEqual(fmt, "mp3")
+            self.assertEqual(audio_data, b"processed_audio") # Audio comes from mocked open after ffmpeg
+
+            # Check that tempfile.NamedTemporaryFile was called to create tts and merged files
+            self.assertEqual(mock_tempfile_creator.call_count, 2)
+
+            # Check that tts_file.write was called with the concatenated raw audio
+            mock_temp_file_tts.write.assert_called_once_with(expected_raw_audio)
+
+            # Check that hass.async_add_executor_job was used for subprocess.run
+            self.hass.async_add_executor_job.assert_called()
+            # Check that subprocess.run was called (args depend on chime/norm options)
+            mock_subprocess_run.assert_called()
+            # Check that temp files were removed
+            self.assertGreaterEqual(mock_os_remove.call_count, 2)
+
+
+    async def test_async_get_tts_audio_engine_error(self):
+        """Test error handling when the TTS engine's get_tts fails."""
+        entity = self._setup_entity(self.openai_config_data)
+        self.mock_engine.get_tts = AsyncMock(side_effect=HomeAssistantError("Engine failed"))
+
+        fmt, audio_data = await entity.async_get_tts_audio("Test error", "en-US", options={})
+
+        self.assertIsNone(fmt)
+        self.assertIsNone(audio_data)
+        # Add log check if possible/needed: _LOGGER.exception("Unknown error in get_tts_audio")
+
+    async def test_async_will_remove_from_hass(self):
+        """Test that async_will_remove_from_hass calls engine.close()."""
+        entity = self._setup_entity(self.openai_config_data)
+        self.mock_engine.close = AsyncMock() # Ensure close is an AsyncMock
+
+        await entity.async_will_remove_from_hass()
+        self.mock_engine.close.assert_called_once()
+
+    @patch('custom_components.openai_tts.tts.OpenAITTSEngine') # Patch where it's used
+    async def test_async_setup_entry_kokoro(self, MockOpenAITTSEngineConstructor):
+        """Test async_setup_entry for Kokoro configuration."""
+        mock_engine_instance = MockOpenAITTSEngineConstructor.return_value
+        self.hass.data[DOMAIN] = {} # Ensure domain data exists
+
+        mock_config_entry = MagicMock(spec=ConfigEntry)
+        mock_config_entry.data = self.kokoro_config_data
+        mock_config_entry.options = {}
+
+        async_add_entities_mock = MagicMock()
+
+        await async_setup_entry(self.hass, mock_config_entry, async_add_entities_mock)
+
+        MockOpenAITTSEngineConstructor.assert_called_once_with(
+            api_key=None, # Kokoro specific
+            voice=self.kokoro_config_data[CONF_VOICE],
+            model=self.kokoro_config_data[CONF_MODEL],
+            speed=self.kokoro_config_data[CONF_SPEED],
+            url=self.kokoro_config_data[CONF_KOKORO_URL] # Kokoro URL
+        )
+        async_add_entities_mock.assert_called_once()
+        # Further checks on the entity passed to async_add_entities_mock can be added.
+
+    @patch('custom_components.openai_tts.tts.OpenAITTSEngine')
+    async def test_async_setup_entry_openai(self, MockOpenAITTSEngineConstructor):
+        """Test async_setup_entry for OpenAI configuration."""
+        mock_engine_instance = MockOpenAITTSEngineConstructor.return_value
+        self.hass.data[DOMAIN] = {}
+
+        mock_config_entry = MagicMock(spec=ConfigEntry)
+        mock_config_entry.data = self.openai_config_data
+        mock_config_entry.options = {}
+
+        async_add_entities_mock = MagicMock()
+
+        await async_setup_entry(self.hass, mock_config_entry, async_add_entities_mock)
+
+        MockOpenAITTSEngineConstructor.assert_called_once_with(
+            api_key=self.openai_config_data[CONF_API_KEY],
+            voice=self.openai_config_data[CONF_VOICE],
+            model=self.openai_config_data[CONF_MODEL],
+            speed=self.openai_config_data[CONF_SPEED],
+            url=self.openai_config_data[CONF_URL]
+        )
+        async_add_entities_mock.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces support for Kokoro FastAPI as an alternative TTS engine and refactors the core TTS handling to support streaming audio.

Key changes:

- **Kokoro FastAPI Integration:**
    - You can now select "Kokoro FastAPI" as a TTS engine during configuration.
    - Added a `kokoro_url` configuration option for the Kokoro FastAPI endpoint.
    - `OpenAITTSEngine` and `OpenAITTSEntity` now handle Kokoro-specific configurations (e.g., different API endpoint, no API key).
    - Device manufacturer and entity naming now reflect the chosen engine.

- **Streaming Support:**
    - `OpenAITTSEngine` now uses `aiohttp` for asynchronous HTTP requests and streams audio responses chunk by chunk.
    - `OpenAITTSEntity` has been updated to consume these streamed chunks, concatenating them before any further processing (like chimes or normalization via ffmpeg).
    - Blocking `ffmpeg` calls are now run in Home Assistant's executor thread pool to prevent blocking the event loop.
    - The `aiohttp.ClientSession` is properly closed when the TTS entity is removed.

- **Configuration Updates:**
    - Added `CONF_TTS_ENGINE` and `CONF_KOKORO_URL` constants.
    - `config_flow.py` now dynamically adjusts input fields based on the selected engine.
    - Updated `strings.json` for new UI elements and error messages.

- **Testing:**
    - Added comprehensive unit tests for `OpenAITTSEngine` and `OpenAITTSEntity`.
    - Tests cover engine selection, streaming functionality, error handling, and integration with Home Assistant for both OpenAI and Kokoro FastAPI configurations.

- **Documentation:**
    - Updated `README.md` to document the new Kokoro FastAPI engine option, the `tts_engine` and `kokoro_url` configuration settings, and the internal improvements due to streaming.

This integration allows you more flexibility in choosing your TTS provider and improves the efficiency of audio generation through streaming.