### PR TITLE
Add ability to disable sending the 'voice'-key to the speech API

### DIFF
--- a/custom_components/openai_tts/const.py
+++ b/custom_components/openai_tts/const.py
@@ -18,7 +18,7 @@ MODELS = ["tts-1", "tts-1-hd", "gpt-4o-mini-tts"]
 # recommended highest-quality voices.
 VOICES = [
     "alloy", "ash", "ballad", "cedar", "coral", "echo", "fable",
-    "marin", "nova", "onyx", "sage", "shimmer", "verse",
+    "marin", "nova", "onyx", "sage", "shimmer", "verse", "disabled"
 ]
 
 # Per-model voice support. Used by config_flow to render only the

--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -124,6 +124,9 @@ class _RequestBuilder:
         if instructions is not None:
             payload["instructions"] = instructions
 
+        if (voice or self._default_voice) == "disabled":
+            del payload['voice']
+
         if extra_payload:
             try:
                 extra = json.loads(extra_payload)

--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -420,6 +420,10 @@ class OpenAITTSEngine:
         Auth/quota errors are NOT retried - they will fail again
         identically and waking the speaker twice helps no one.
         """
+
+        if payload['voice'] == "disabled":
+            del payload['voice']
+
         attempt = 0
         while True:
             try:

--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -124,8 +124,8 @@ class _RequestBuilder:
         if instructions is not None:
             payload["instructions"] = instructions
 
-        if (voice or self._default_voice) == "disabled":
-            del payload['voice']
+        #if payload['voice'] == "disabled":
+        #    del payload['voice']
 
         if extra_payload:
             try:

--- a/custom_components/openai_tts/openaitts_engine.py
+++ b/custom_components/openai_tts/openaitts_engine.py
@@ -124,9 +124,6 @@ class _RequestBuilder:
         if instructions is not None:
             payload["instructions"] = instructions
 
-        #if payload['voice'] == "disabled":
-        #    del payload['voice']
-
         if extra_payload:
             try:
                 extra = json.loads(extra_payload)
@@ -225,6 +222,9 @@ class OpenAITTSEngine:
             "TTS API request: model=%s, voice=%s, speed=%s",
             payload["model"], payload["voice"], payload["speed"],
         )
+
+        if payload['voice'] == "disabled":
+            del payload['voice']
 
         max_retries = 1
         attempt = 0

--- a/custom_components/openai_tts/services.yaml
+++ b/custom_components/openai_tts/services.yaml
@@ -62,6 +62,8 @@ say:
               value: shimmer
             - label: Verse (Versatile) · gpt-4o-mini-tts only
               value: verse
+            - label: Disabled (don't send voice value)
+              value: disabled
     speed:
       name: Speed
       description: Speed of the speech (0.25-4.0). 1.0 is normal speed.


### PR DESCRIPTION
**Problem**
In some cases the TTS provider does not accept the 'voice' key in the request, nor does it accept a NULL value (through the extra parameters option). This is the case for audio.cpp when using the 'Chatterbox' or 'VoxCPM2' model.

**Solution**
Add the ability to use voice 'disabled' to omit the 'voice'-key in the TTS request.

_Disclaimer: I normally don't code in Python, so there might be better ways to handle this. This solution does however work for me._