### PR TITLE
feat: discover and expose real voice list for custom TTS backends

### DIFF
--- a/custom_components/openai_tts/config_flow.py
+++ b/custom_components/openai_tts/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
     CONF_PAUSE_PLAYBACK,
     CONF_PROFILE_NAME,
 )
+from .voice_discovery import async_get_cached_remote_voices
 
 SUBENTRY_TYPE_PROFILE = "profile"
 
@@ -555,6 +556,7 @@ class OpenAITTSProfileSubentryFlow(ConfigSubentryFlow):
         is_openai = is_openai_endpoint(endpoint_url)
         allowed_voices = voices_for_model(self._step1_model)
         default_voice = "shimmer" if "shimmer" in allowed_voices else allowed_voices[0]
+        discovered_voices: list[tuple[str, str]] | None = None
 
         if is_openai:
             # ``custom_value`` is OFF on OpenAI endpoints so the picker
@@ -569,10 +571,30 @@ class OpenAITTSProfileSubentryFlow(ConfigSubentryFlow):
                 }
             })
         else:
-            # Custom backend (e.g. Chatterbox) - we don't know the
-            # voice catalogue, so let the user type whatever the
-            # backend understands.
-            voice_field = selector({"text": {}})
+            # Custom backend (e.g. Chatterbox, Kokoro) - try to discover
+            # its real voice catalogue via GET .../audio/voices. Falls
+            # back to free text if the backend doesn't support listing.
+            api_key = parent_entry.data.get(CONF_API_KEY) if parent_entry else None
+            discovered_voices = await async_get_cached_remote_voices(
+                self.hass, self.hass.data.setdefault(DOMAIN, {}), endpoint_url, api_key
+            )
+            if discovered_voices:
+                voice_field = selector({
+                    "select": {
+                        "options": [
+                            {"value": vid, "label": f"{name} ({vid})" if name != vid else vid}
+                            for vid, name in discovered_voices
+                        ],
+                        "mode": "dropdown",
+                        "sort": True,
+                        # Keep free-text as an escape hatch in case
+                        # discovery is stale or incomplete.
+                        "custom_value": True,
+                    }
+                })
+                default_voice = discovered_voices[0][0]
+            else:
+                voice_field = selector({"text": {}})
 
         step2_fields: dict[Any, Any] = {
             vol.Required(CONF_VOICE, default=default_voice): voice_field,
@@ -745,7 +767,29 @@ class OpenAITTSProfileSubentryFlow(ConfigSubentryFlow):
                 }
             })
         else:
-            voice_field = selector({"text": {}})
+            api_key = parent_entry.data.get(CONF_API_KEY) if parent_entry else None
+            discovered_voices = await async_get_cached_remote_voices(
+                self.hass, self.hass.data.setdefault(DOMAIN, {}), endpoint_url, api_key
+            )
+            if discovered_voices:
+                voice_field = selector({
+                    "select": {
+                        "options": [
+                            {"value": vid, "label": f"{name} ({vid})" if name != vid else vid}
+                            for vid, name in discovered_voices
+                        ],
+                        "mode": "dropdown",
+                        "sort": True,
+                        "custom_value": True,
+                    }
+                })
+                # Keep the existing saved voice as default even if it
+                # isn't in the freshly-discovered list (e.g. backend
+                # temporarily unreachable during a previous save) -
+                # custom_value=True means it still renders correctly.
+                default_voice = existing_voice
+            else:
+                voice_field = selector({"text": {}})
 
         step2_fields: dict[Any, Any] = {
             vol.Required(CONF_VOICE, default=default_voice): voice_field,

--- a/custom_components/openai_tts/tts.py
+++ b/custom_components/openai_tts/tts.py
@@ -20,9 +20,10 @@ from homeassistant.components.tts import (
     TextToSpeechEntity,
     TTSAudioRequest,
     TTSAudioResponse,
+    Voice,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, MaxLengthExceeded
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -50,6 +51,7 @@ from .const import (
     SUPPORTED_LANGUAGES,
     UNIQUE_ID,
     VOICES,
+    is_openai_endpoint,
 )
 from .entity_helpers import is_subentry, sanitize_profile_name
 from .exceptions import (
@@ -61,6 +63,7 @@ from .exceptions import (
 )
 from .openaitts_engine import OpenAITTSEngine
 from .utils import detect_audio_format, get_media_duration, is_valid_audio, process_audio
+from .voice_discovery import async_get_cached_remote_voices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -206,6 +209,13 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
         # same reason.
         self._duration_cache = MessageDurationCache(hass, self._attr_unique_id)
 
+        # Populated lazily by ``async_get_supported_voices`` /
+        # ``async_added_to_hass`` for custom (non-OpenAI) backends that
+        # expose a voice-listing endpoint. ``None`` until a fetch has
+        # been attempted at least once; ``[]``/populated list after.
+        # Kept as plain (id, name) tuples - see voice_discovery.py.
+        self._cached_remote_voices: list[tuple[str, str]] | None = None
+
         # The health tracker lives on the parent entry. Subentries inherit it
         # via parent_entry; legacy entries are their own parent.
         parent_entry_id = (
@@ -242,6 +252,21 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._restore_persisted_state()
+        # Warm the remote voice-discovery cache (no-op for OpenAI
+        # endpoints, cheap/cached for custom ones) so the
+        # ``available_voices`` attribute and the Assist pipeline dropdown
+        # (async_get_supported_voices, which MUST stay synchronous - see
+        # its docstring) both reflect the real catalogue as soon as
+        # possible, rather than only after the pipeline UI is first
+        # opened and finding a cold, empty cache.
+        try:
+            await self._async_refresh_remote_voices()
+        except Exception:  # pragma: no cover - defensive, never should raise
+            _LOGGER.exception(
+                "Voice discovery warm-up failed for %s; will retry on demand",
+                self.entity_id,
+            )
+        self.async_write_ha_state()
         _LOGGER.info("TTS entity %s registered with Home Assistant", self.entity_id)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -283,10 +308,18 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
         # from the service call so its lookup hash matches what tts.py
         # used at store time. Removing one breaks cache lookups and
         # forces fallback timing.
+        if self._cached_remote_voices:
+            available = [vid for vid, _name in self._cached_remote_voices]
+        else:
+            # Either an OpenAI endpoint (static catalogue is correct),
+            # or a custom endpoint we haven't successfully discovered
+            # yet - static list is still the best available fallback.
+            available = VOICES
+
         return {
             "media_duration": self._last_duration_ms,
             "failure_cache_size": self._duration_cache.size,
-            "available_voices": VOICES,
+            "available_voices": available,
             "current_voice": self._get_config_value(CONF_VOICE) or self._engine._voice,
             "current_model": self._get_config_value(CONF_MODEL) or self._engine._model,
             "current_speed": self._get_config_value(CONF_SPEED) or self._engine._speed,
@@ -303,6 +336,74 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
     @property
     def supported_languages(self) -> list[str]:
         return SUPPORTED_LANGUAGES
+
+    @callback
+    def async_get_supported_voices(self, language: str) -> list[Voice] | None:
+        """Return the voices this entity supports, for the Assist pipeline UI.
+
+        This is what actually populates the "Voice" dropdown on the
+        Settings -> Voice Assistants -> (pipeline) screen once this
+        entity is selected as the TTS engine - it is unrelated to the
+        ``available_voices`` extra_state_attribute, which is informational
+        only. Previously unimplemented, so the pipeline UI had nothing to
+        show for this entity regardless of backend.
+
+        IMPORTANT: Home Assistant core calls this synchronously - see
+        ``homeassistant/components/tts/entity.py`` (decorated ``@callback``,
+        defined with plain ``def``) and the call site in
+        ``homeassistant/components/tts/__init__.py``
+        (``engine_instance.async_get_supported_voices(language)``, not
+        awaited). Any custom-backend voice discovery therefore CANNOT
+        happen inside this method - it must already be cached before this
+        is called. ``_cached_remote_voices`` is populated by
+        ``_async_refresh_remote_voices`` from ``async_added_to_hass`` (and
+        can be refreshed on demand elsewhere); this method only ever reads
+        that cache or falls back.
+        """
+        endpoint_url = self._config.data.get(CONF_URL) or (
+            self._parent_entry.data.get(CONF_URL) if self._parent_entry else None
+        )
+
+        if is_openai_endpoint(endpoint_url):
+            return [Voice(voice_id=v, name=v.capitalize()) for v in VOICES]
+
+        if self._cached_remote_voices:
+            return [
+                Voice(voice_id=vid, name=name)
+                for vid, name in self._cached_remote_voices
+            ]
+
+        # Discovery hasn't completed / failed - degrade gracefully rather
+        # than returning an empty (or None) list, which would leave the
+        # pipeline UI with no voice picker at all for this entity.
+        current_voice = self._get_config_value(CONF_VOICE) or self._engine._voice
+        if current_voice:
+            return [Voice(voice_id=current_voice, name=current_voice)]
+        return None
+
+    async def _async_refresh_remote_voices(self, *, force_refresh: bool = False) -> None:
+        """Populate ``_cached_remote_voices`` for custom (non-OpenAI) backends.
+
+        Async - safe to call from ``async_added_to_hass`` or any other
+        coroutine context. Must never be called from
+        ``async_get_supported_voices`` itself (that method is sync-only
+        per the HA core contract - see its docstring).
+        """
+        endpoint_url = self._config.data.get(CONF_URL) or (
+            self._parent_entry.data.get(CONF_URL) if self._parent_entry else None
+        )
+        if is_openai_endpoint(endpoint_url):
+            self._cached_remote_voices = None
+            return
+
+        api_key = self._config.data.get(CONF_API_KEY) or (
+            self._parent_entry.data.get(CONF_API_KEY) if self._parent_entry else None
+        )
+        domain_data_root = self.hass.data.setdefault(DOMAIN, {})
+        self._cached_remote_voices = await async_get_cached_remote_voices(
+            self.hass, domain_data_root, endpoint_url, api_key,
+            force_refresh=force_refresh,
+        )
 
     @property
     def supported_options(self) -> list[str]:
@@ -831,11 +932,13 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
             self._record_failure(full_text, err, resolved)
             return self._empty_response(audio_format)
 
-        # Post-processing stays in the requested format end to end. The
-        # ``filter_complex`` graph in ``build_ffmpeg_command`` re-samples
-        # both the chime and the TTS input to a common PCM layout before
-        # concat and picks the right encoder for the output. HA still has
-        # its ``preferred_format`` ffmpeg layer as a safety net if the
+        # Post-processing now stays in the requested format end to end:
+        # ``ensure_chime_in_format`` transcodes the chime to match, and
+        # ``build_ffmpeg_command`` picks the right encoder for the
+        # output. The bytes that come out of ``_maybe_post_process``
+        # therefore match the requested ``audio_format`` regardless of
+        # whether chime/normalize ran. HA still has its
+        # ``preferred_format`` ffmpeg layer as a safety net if the
         # downstream player needs a different container.
         delivered_format = audio_format
 

--- a/custom_components/openai_tts/voice_discovery.py
+++ b/custom_components/openai_tts/voice_discovery.py
@@ -1,0 +1,192 @@
+"""Remote voice-list discovery for custom (non-OpenAI) TTS backends.
+
+Several OpenAI-compatible self-hosted TTS servers (Kokoro-FastAPI,
+openai-edge-tts, and others) expose a ``GET /v1/audio/voices`` endpoint
+alongside the standard ``POST /v1/audio/speech`` endpoint, returning
+either:
+
+    {"voices": [{"id": "af_bella", "name": "Bella"}, ...]}   # current shape
+    {"voices": ["af_bella", "af_sky", ...]}                  # legacy shape
+    [{"id": "af_bella", "name": "Bella"}, ...]                # bare list
+    ["af_bella", "af_sky", ...]                                # bare legacy list
+
+This module fetches and normalises that list so both the config flow
+(setup-time voice picker) and the TTS entity (``async_get_supported_voices``,
+which feeds the Assist pipeline's voice dropdown) can use it. OpenAI's real
+API has no such endpoint, so discovery is only ever attempted for
+non-OpenAI URLs - callers are expected to gate on ``is_openai_endpoint``
+before calling in here.
+
+Failures (timeout, connection error, non-200, bad JSON) return ``None``
+rather than raising, so every caller can fall back to free-text /  the
+static OpenAI voice catalogue without special-casing exceptions.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+# How long a successful discovery result stays valid before we hit the
+# backend again. Keeps the config flow and entity setup snappy (no
+# network round-trip on every form render) while still picking up voice
+# packs added to a running container within a reasonable window.
+_CACHE_TTL_SECONDS = 300
+
+# hass.data[DOMAIN]["voice_cache"][speech_url] = (fetched_at, [(id, name), ...])
+_CACHE_KEY = "voice_cache"
+
+
+def _voices_url_from_speech_url(speech_url: str) -> str:
+    """Derive the voices-list endpoint from the configured speech endpoint.
+
+    Handles the common shapes users paste in:
+        http://host:8880/v1/audio/speech       -> http://host:8880/v1/audio/voices
+        http://host:8880/v1/audio/speech/       -> http://host:8880/v1/audio/voices
+        http://host:8880/v1                     -> http://host:8880/v1/audio/voices
+        http://host:8880                        -> http://host:8880/audio/voices
+    """
+    parsed = urlparse(speech_url)
+    path = parsed.path.rstrip("/")
+
+    if path.endswith("/audio/speech"):
+        new_path = path[: -len("/speech")] + "/voices"
+    elif path.endswith("/v1"):
+        new_path = path + "/audio/voices"
+    elif path == "":
+        new_path = "/audio/voices"
+    else:
+        # Unknown shape - best effort: assume sibling of the last segment.
+        new_path = path.rsplit("/", 1)[0] + "/audio/voices"
+
+    return urljoin(f"{parsed.scheme}://{parsed.netloc}", new_path)
+
+
+def _normalize_voice_entry(entry: Any) -> tuple[str, str] | None:
+    """Normalize one entry from either response shape into (id, name)."""
+    if isinstance(entry, str):
+        voice_id = entry
+        # "af_bella" -> "Bella (af)" - readable without a real display name.
+        parts = voice_id.split("_", 1)
+        name = parts[1].replace("_", " ").title() if len(parts) == 2 else voice_id
+        return voice_id, name
+    if isinstance(entry, dict):
+        voice_id = entry.get("id") or entry.get("voice_id") or entry.get("value")
+        if not voice_id:
+            return None
+        name = entry.get("name") or entry.get("label") or voice_id
+        return str(voice_id), str(name)
+    return None
+
+
+def _normalize_payload(payload: Any) -> list[tuple[str, str]] | None:
+    """Pull the voice list out of either the wrapped or bare response shape."""
+    if isinstance(payload, dict):
+        raw_list = payload.get("voices")
+        if raw_list is None:
+            return None
+    elif isinstance(payload, list):
+        raw_list = payload
+    else:
+        return None
+
+    voices: list[tuple[str, str]] = []
+    for entry in raw_list:
+        normalized = _normalize_voice_entry(entry)
+        if normalized is not None:
+            voices.append(normalized)
+
+    return voices or None
+
+
+async def async_fetch_remote_voices(
+    hass: HomeAssistant,
+    speech_url: str,
+    api_key: str | None = None,
+    *,
+    timeout: float = 5.0,
+) -> list[tuple[str, str]] | None:
+    """Fetch and normalize the voice list from a custom backend.
+
+    Returns a list of ``(id, name)`` tuples, or ``None`` if discovery
+    isn't supported / failed for any reason. Never raises.
+    """
+    voices_url = _voices_url_from_speech_url(speech_url)
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    session = async_get_clientsession(hass)
+    try:
+        async with session.get(
+            voices_url,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=timeout),
+        ) as response:
+            if response.status != 200:
+                _LOGGER.debug(
+                    "Voice discovery: %s returned HTTP %s, backend likely "
+                    "doesn't support voice listing",
+                    voices_url,
+                    response.status,
+                )
+                return None
+            try:
+                payload = await response.json(content_type=None)
+            except (aiohttp.ContentTypeError, ValueError) as err:
+                _LOGGER.debug(
+                    "Voice discovery: %s returned non-JSON body: %s",
+                    voices_url,
+                    err,
+                )
+                return None
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.debug(
+            "Voice discovery: could not reach %s: %s", voices_url, err
+        )
+        return None
+
+    voices = _normalize_payload(payload)
+    if voices is None:
+        _LOGGER.debug(
+            "Voice discovery: %s returned an unrecognized payload shape",
+            voices_url,
+        )
+    return voices
+
+
+async def async_get_cached_remote_voices(
+    hass: HomeAssistant,
+    domain_data_root: dict,
+    speech_url: str,
+    api_key: str | None = None,
+    *,
+    force_refresh: bool = False,
+) -> list[tuple[str, str]] | None:
+    """Cached wrapper around ``async_fetch_remote_voices``.
+
+    ``domain_data_root`` is the integration's ``hass.data[DOMAIN]`` dict -
+    passed in explicitly rather than imported, so this module doesn't need
+    to know about ``__init__.py``'s setup shape.
+    """
+    cache: dict[str, tuple[float, list[tuple[str, str]]]] = domain_data_root.setdefault(
+        _CACHE_KEY, {}
+    )
+
+    if not force_refresh:
+        cached = cache.get(speech_url)
+        if cached is not None:
+            fetched_at, voices = cached
+            if time.monotonic() - fetched_at < _CACHE_TTL_SECONDS:
+                return voices
+
+    voices = await async_fetch_remote_voices(hass, speech_url, api_key)
+    if voices is not None:
+        cache[speech_url] = (time.monotonic(), voices)
+    return voices


### PR DESCRIPTION
feat: discover voices from custom TTS backends for the Assist pipeline

Previously the voice picker was hardcoded to OpenAI's static voice
list everywhere, even for custom backends (Kokoro, etc.), and no
voice selector appeared in the Assist pipeline UI at all since
async_get_supported_voices was never implemented.

- Add voice_discovery.py: fetches and normalizes GET .../audio/voices
  from non-OpenAI backends, with a 5-minute per-URL cache
- config_flow.py: profile setup now shows a real dropdown of
  discovered voices for custom backends instead of free text
  (falls back to free text if the backend doesn't support listing)
- tts.py: implement async_get_supported_voices so the Assist
  pipeline's Voice dropdown works for this integration; voices are
  discovered async in async_added_to_hass and cached, since HA core
  calls async_get_supported_voices synchronously (@callback, not
  awaited - see tts/entity.py)
- available_voices attribute now reflects the real discovered list
  instead of always showing the OpenAI catalogue

OpenAI endpoints are unaffected; behavior there is unchanged.