### PR TITLE
Advertise BCP-47 region language tags

### DIFF
--- a/custom_components/openai_tts/const.py
+++ b/custom_components/openai_tts/const.py
@@ -494,6 +494,33 @@ SUPPORTED_LANGUAGES = [
     "zh",  # Chinese
 ]
 
+# Region-qualified (BCP-47) tags accepted *in addition to* the base
+# ISO-639-1 codes above. Home Assistant validates a caller's language
+# by EXACT membership in ``supported_languages`` with no tag
+# normalisation (homeassistant/components/tts/__init__.py). Clients that
+# send a full tag — e.g. Music Assistant AI Radio sends the host
+# language "en-US" — are otherwise rejected with
+# ``Language 'en-US' not supported`` even though the OpenAI backend
+# auto-detects voice/language from the text and never receives the tag.
+# Each tag maps to a base code already in the list; accepting them is a
+# pure compatibility expansion, not a new capability.
+_REGION_TAGS: dict[str, tuple[str, ...]] = {
+    "en": ("en-US", "en-GB", "en-AU", "en-CA", "en-IE", "en-IN"),
+    "pt": ("pt-BR", "pt-PT"),
+    "zh": ("zh-CN", "zh-TW", "zh-HK"),
+    "nb": ("nb-NO",),
+    "sr": ("sr-Latn",),
+}
+
+# Base codes plus region-qualified variants, in stable order. Exposed so
+# the entity can advertise every tag Home Assistant will accept.
+SUPPORTED_LANGUAGES_WITH_REGIONS: list[str] = list(SUPPORTED_LANGUAGES)
+for _base, _variants in _REGION_TAGS.items():
+    for _tag in _variants:
+        if _tag not in SUPPORTED_LANGUAGES_WITH_REGIONS:
+            SUPPORTED_LANGUAGES_WITH_REGIONS.append(_tag)
+del _base, _variants, _tag
+
 CONF_CHIME_ENABLE = "chime"
 CONF_CHIME_SOUND = "chime_sound"
 CONF_NORMALIZE_AUDIO = "normalize_audio"

--- a/custom_components/openai_tts/tts.py
+++ b/custom_components/openai_tts/tts.py
@@ -58,6 +58,7 @@ from .const import (
     DEFAULT_SEND_VOICE,
     DOMAIN,
     SUPPORTED_LANGUAGES,
+    SUPPORTED_LANGUAGES_WITH_REGIONS,
     UNIQUE_ID,
     preset_for,
     is_openai_endpoint,
@@ -469,7 +470,7 @@ class OpenAITTSEntity(TextToSpeechEntity, RestoreEntity):
 
     @property
     def supported_languages(self) -> list[str]:
-        return SUPPORTED_LANGUAGES
+        return SUPPORTED_LANGUAGES_WITH_REGIONS
 
     def _available_voice_ids(self) -> list[str]:
         """Voice names for the attribute, matching what the entity offers.


### PR DESCRIPTION
## What

Advertise BCP-47 region-qualified language tags (e.g. `en-US`, `pt-BR`,
`zh-CN`) for every base ISO-639-1 code the component already supports.

Home Assistant validates a caller's TTS language by **exact membership** in
`supported_languages` with no tag normalisation
(`homeassistant/components/tts/__init__.py`), so any client that sends a full
tag is rejected with `Language 'en-US' not supported` — even though the OpenAI
backend auto-detects voice/language from the text and never receives the tag.

## Why it matters (Music Assistant AI Radio)

Music Assistant's AI Radio feature sends the host system language to the TTS
engine. On an `en-US` HA install that is the literal string `en-US`. Before
this change every AI Radio announcement segment failed with an HTTP 500 in a
retry loop:

```
WARNING [music_assistant.AI Radio] TTS request to engine 'tts.openai_tts_lewis'
  for language 'en-US' failed (HTTP 500)
```

The exact-membership gate is the only thing rejecting the request — the OpenAI
backend never sees the language tag and would have rendered the text fine. The
region tags added here map 1:1 to base codes already in the list, so this is a
pure compatibility expansion: no capability change, no change to what audio is
generated.

## Test

- `supported_languages` now returns the base codes **plus** the region tags
  (54 → 67 languages, `en-US` present).
- A `tts.speak` that previously failed with `Language 'en-US' not supported`
  (HTTP 500) now returns 200 and plays audio.
